### PR TITLE
Declare compatibility with Ruby 3.x in addition to 2.x

### DIFF
--- a/minitest-reporters-json_reporter.gemspec
+++ b/minitest-reporters-json_reporter.gemspec
@@ -19,7 +19,7 @@ See: https://atom.io. Originally written to interface with the Viper Audible edi
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0', '<= 3.0'
 
   spec.add_runtime_dependency 'minitest-reporters', '~> 1.1', '>= 1.1.8'
 


### PR DESCRIPTION
With this change, I believe this gem works with Ruby 3. All tests pass, and I've tried using the gem with this change with a Rails app under Ruby 3.0.0, and it worked.